### PR TITLE
Update nabla_w -> nabla_{\vec{w}}

### DIFF
--- a/w05_function_approx/t02_vfa_grad.tex
+++ b/w05_function_approx/t02_vfa_grad.tex
@@ -60,7 +60,7 @@
 	$$
 	\nabla J(\vec{w}) = \left[ \frac{\partial J}{\vec{w}_1} \ldots \frac{\partial J}{\vec{w}_n} \right]
 	$$
-	$$\vec{w}_t = \vec{w}_{t-1} - \alpha \nabla_w J(\vec{w})$$
+	$$\vec{w}_t = \vec{w}_{t-1} - \alpha \nabla_{\vec{w}} J(\vec{w})$$
 	
 	where $\alpha$ is the learning rate.
 


### PR DESCRIPTION
While tracing a error while compiling I found this line in which nabla_w instead of nabla_\vec{w} is used. To remove the compiler error this \vec{w} also has to be surrounded by braces