### PR TITLE
Update t03_exploration.tex

### DIFF
--- a/w04_model_free_control/t03_exploration.tex
+++ b/w04_model_free_control/t03_exploration.tex
@@ -79,7 +79,7 @@ Q^{\pi_i} (s,\pi_{i+1} (s)) &=& \sum_{a \in A} \pi_{i+1}(a \mid s) Q^{\pi_{i}}(s
 	&=& (\epsilon / |A|) \left[\sum_{a\in A} Q^{\pi_{i}}(s,a) \right] + (1- \epsilon) \max_{a\in A} Q^{\pi_{i}}(s,a)\nonumber\\
 	&=& (\epsilon / |A|) \left[\sum_{a\in A} Q^{\pi_{i}}(s,a) \right] + (1- \epsilon) \max_{a\in A} Q^{\pi_{i}}(s,a)\frac{1-\epsilon}{1-\epsilon}\nonumber\\
 	&=& (\epsilon / |A|) \left[\sum_{a\in A} Q^{\pi_{i}}(s,a) \right] + (1- \epsilon) \max_{a\in A} Q^{\pi_{i}}(s,a)\sum_{a\in A}\frac{\pi_i(a\mid s) - \frac{\epsilon}{|A|}}{1-\epsilon}\nonumber\\
-	&\geq& (\epsilon / |A|) \left[\sum_{a\in A} Q^{\pi_{i}}(s,a) \right] + (1- \epsilon) \qquad~ Q^{\pi_{i}}(s,a)\sum_{a\in A}\frac{\pi_i(a\mid s) - \frac{\epsilon}{|A|}}{1-\epsilon} \nonumber\\
+	&\geq& (\epsilon / |A|) \left[\sum_{a\in A} Q^{\pi_{i}}(s,a) \right] + (1- \epsilon) \qquad~ \sum_{a\in A}Q^{\pi_{i}}(s,a)\frac{\pi_i(a\mid s) - \frac{\epsilon}{|A|}}{1-\epsilon} \nonumber\\
 	&=& \sum_{a\in A} \pi_i (a \mid s) Q^{\pi_i}(s,a) = V^{\pi_i}(s)\nonumber
 \end{eqnarray}
 	


### PR DESCRIPTION
I think Q^{\pi_{i}}(s,a) has to be inside the summation or else the term would have 'a' as a free variable but that cannot be the case since the entire term is equal to V^{\pi_i}(s) which only has 's' as a free variable