### PR TITLE
Update t02_gradient_free.tex

### DIFF
--- a/w07_policy_search/t02_gradient_free.tex
+++ b/w07_policy_search/t02_gradient_free.tex
@@ -77,10 +77,10 @@
 	}
 	\For{$t=0,1, \ldots, T$}{
 		\For{$i=1,2, \ldots, \lambda$}{ 
-			{$\epsilon_i\sim\mathcal{N}(0,I)$}\;\\
+			{$\epsilon_i\sim\mathcal{N}(0,1)$}\;\\
 			$s_i\leftarrow F(\theta_t+\sigma\cdot\epsilon_i)$
 		}
-		Sort $(\epsilon_1,\ldots,\epsilon_\lambda)$ according to $s$ in ascending order\\
+		Sort $(\epsilon_1,\ldots,\epsilon_\lambda)$ according to $s$ in descending order\\
 		{Update policy: $\theta_{t+1}\leftarrow \theta_t + \sigma\cdot\sum\nolimits_{j=1}^\mu w_j\cdot\epsilon_j$}
 	}
 	\KwOut{{} Return best found policy $\theta_t$}

--- a/w07_policy_search/t02_gradient_free.tex
+++ b/w07_policy_search/t02_gradient_free.tex
@@ -77,7 +77,7 @@
 	}
 	\For{$t=0,1, \ldots, T$}{
 		\For{$i=1,2, \ldots, \lambda$}{ 
-			{$\epsilon_i\sim\mathcal{N}(0,1)$}\;\\
+			{$\epsilon_i\sim\mathcal{N}(0,I)$}\;\\
 			$s_i\leftarrow F(\theta_t+\sigma\cdot\epsilon_i)$
 		}
 		Sort $(\epsilon_1,\ldots,\epsilon_\lambda)$ according to $s$ in descending order\\


### PR DESCRIPTION
-Fixed a typo in the notation for normal distribution
Im not so sure about my second change, but I think the tuple (\epsilon_1,\ldots,\epsilon_\lambda) has to be sorted in descending order in accordance to s since we are maximizing V and thus we want to step in the direction that maximizes V.