### PR TITLE
Update relative path of image

### DIFF
--- a/w07_policy_search/t07_step_size.tex
+++ b/w07_policy_search/t07_step_size.tex
@@ -202,7 +202,7 @@
     \end{itemize}
     
     \centering
-    \includegraphics[width=0.5\textwidth]{w07_policy_search/images/trpo.PNG}\\
+    \includegraphics[width=0.5\textwidth]{images/trpo.PNG}\\
     \lit{Schulman et al. 2015}{https://arxiv.org/abs/1502.05477}
 
 \end{frame}


### PR DESCRIPTION
The pipeline currently fails because the path to the image was given relativ to the root-folder. I hope this change fixes the pipeline.

![image](https://user-images.githubusercontent.com/20955739/143322582-8485a394-ce43-47d0-9251-d8cba6b272fc.png)
