### PR TITLE
Update t05_pred_intrinsic_exploration.tex

### DIFF
--- a/w08_exploration/t05_pred_intrinsic_exploration.tex
+++ b/w08_exploration/t05_pred_intrinsic_exploration.tex
@@ -77,11 +77,11 @@
 		\item hash-function~\lit{Tang et al. 2016}{https://arxiv.org/abs/1611.04717}
 		\item Autoencoder~\lit{Stadie et al. 2015}{https://arxiv.org/abs/1507.00814}
 		\item Self-supervised inverse dynamic models~\lit{Pathak et al. 2017}{https://arxiv.org/abs/1705.05363}
-		$$g: (\phi(s_t), \phi(s_{t+1})) \mapsto a_t $$
+		$$g: (s_t, s_{t+1}) \mapsto h(\phi(s_t), \phi(s_{t+1})) = \hat{a}_t $$
 		\begin{itemize}
 			\item The encoding will focus on the parts of state features that influenced the agent behavior
 			\item Use $\phi$ to learn a forward model $f: (\phi(s_t), a_t) \mapsto \phi(s_{t+1})$
-			$$ r_t^i = || f(\phi(s_{t})) - \phi(s_{t+1})||^2_2$$
+			$$ r_t^i = || f(\phi(s_{t}), a_t) - \phi(s_{t+1})||^2_2$$
 		\end{itemize}
 	\end{itemize}
 	


### PR DESCRIPTION
-Added missing parameter (a_t)
-Inverse dynamics function g according to the paper https://arxiv.org/abs/1705.05363 has the non-encoded states as input. The encoding takes place in the first sublayer of network that computes g