### PR TITLE
Inconsistent notations and typos

### DIFF
--- a/w02_basics/t02_markov_process.tex
+++ b/w02_basics/t02_markov_process.tex
@@ -87,7 +87,7 @@ $$P_{i,j} = P(s_i \mid s_j) $$
 \begin{frame}[c]{Applications}
 
 	\begin{itemize}
-		\item Google's page rank with originally based on a random walk 
+		\item Google's page rank was originally based on a random walk 
 		\begin{itemize}
 			\item Follow links on homepages
 			\item Rank websites based on probability to discover this page

--- a/w02_basics/t04_markov_decision_process.tex
+++ b/w02_basics/t04_markov_decision_process.tex
@@ -119,7 +119,7 @@
 	\item Goal: For a given $\pi$, determine $V^\pi$
 	\item iterative approach:
 	\begin{itemize}
-		\item Initialize $V_0(s) = 0 $ for all s
+		\item Initialize $V^\pi_0(s) = 0 $ for all s
 		\item For $k=1$ until convergence
 		\begin{itemize}
 			\item For all $s$ in $S$:

--- a/w02_basics/t05_policy_iteration.tex
+++ b/w02_basics/t05_policy_iteration.tex
@@ -30,7 +30,7 @@
 	\item Initialize $\pi_0(s)$ randomly for all states $s$
 	\item While $i == 0$ or\\ $||\pi_i - \pi_{i-1}||_1 > 0$ (L1-norm, measures if the policy changed for any state)
 	\begin{itemize}
-		\item $V^{\pi_i} \gets$ MDP V-function policy evaluation of $\pi$
+		\item $V^{\pi_i} \gets$ MDP V-function policy evaluation of $\pi_i$
 		\item $\pi_{i+1} \gets$ Policy improvement
 		\item $i \gets i+1$
 	\end{itemize}

--- a/w07_policy_search/t06_pg_algorithms.tex
+++ b/w07_policy_search/t06_pg_algorithms.tex
@@ -74,7 +74,7 @@ REINFORCE:
 	\item Initialize policy parameters $\theta$ arbitrarily
 	\item for each episode $\{s_1, a_1, r_2, \ldots, s_{T-1}, a_{T-1}, r_T \} \sim \pi_\theta $ do
 	\begin{itemize}
-		\item for $t=1$ to $T - 1$ do
+		\item for $t=0$ to $T - 1$ do
 		\begin{itemize}
 			\item $\theta := \theta + \alpha \nabla_\theta \log \pi_\theta (s_t, a_t) G_t $
 		\end{itemize}


### PR DESCRIPTION
In `w02_basics/t02_markov_process.tex`: "with" should be "was"

In `w02_basics/t04_markov_decision_process.tex`: more consistent notation of V

In `w02_basics/t05_policy_iteration.tex`: adding index i makes evaluated policy more specific

In `w07_policy_search/t06_pg_algorithms.tex`: according to previous slide loop should start at 0